### PR TITLE
Generate documentation for all modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.o
 *.pm.tdy
 *.bs
+/lib/**/*.pod
 
 # ExtUtils::MakeMaker
 /blib/

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -3,8 +3,12 @@
 \.git/.*
 \.gitignore
 
+blib/.*
+YuiRestClient-.*
+
+pm_to_blib
 MANIFEST.SKIP
 Makefile
 Makefile.PL
 README.pod
-.*.tag.gz
+.*.tar.gz

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,9 +2,11 @@ use 5.018;
 use ExtUtils::MakeMaker;
 
 # Generate README.pod and inject current version to it and output as README
+# Also, trye generate pod for all pm in lib directory
 my $preop =
-  'perldoc -uT $(VERSION_FROM) | sed s/%VERSION%/$(VERSION)/ > README.pod;' .
-  'pod2text README.pod | tee $(DISTVNAME)/README > README';
+  'perldoc -uTF $(VERSION_FROM) | sed s/%VERSION%/$(VERSION)/ > README.pod; \\' .
+  'pod2text README.pod | tee $(DISTVNAME)/README > README; \\' .
+  'find lib/ | grep -oP ".*(?=\.pm)" | xargs -I{} perldoc -uTF -d $(DISTVNAME)/{}.pod {}.pm || true';
 
 WriteMakefile(
     NAME             => 'YuiRestClient',

--- a/README.pod
+++ b/README.pod
@@ -3,7 +3,6 @@
 YuiRestClient - Perl module to interact with YaST applications via libyui-rest-api.
 
 
-
 =head1 DESCRIPTION
 
 See documentation of the L<libyui-rest-api project|https://github.com/libyui/libyui/tree/master/libyui-rest-api/doc>.
@@ -13,7 +12,6 @@ for more details about server side implementation.
 =head1 VERSION
 
 This document describes L<YuiRestClient> version B<0.1>.
-
 
 
 =head1 SYNOPSIS
@@ -31,7 +29,6 @@ This document describes L<YuiRestClient> version B<0.1>.
   $btn->click();
 
 
-
 =head1 INSTALLATION
 
 To manually install the package run following commands:
@@ -44,10 +41,9 @@ To generate tarball, execute C<make dist> command. This command will also
 generate README file and update README.pod file.
 
 
-
 =head1 LICENSE
 
-The perl module is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+The perl module is available as open source under the terms of the L<MIT License|https://opensource.org/licenses/MIT>.
 
 
 =cut


### PR DESCRIPTION
Besides README for the project, we should generate pods for all the modules, so documentation is available at CPAN and as a part of tarball.